### PR TITLE
lock pysaml to 2.4.0

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -21,7 +21,7 @@ ldappool>=1.0 # MPL
 
 # Required for federation extension (although used only for federating multiple
 # Keystones)
-pysaml2
+pysaml2==2.4.0
 
 # Testing
 # computes code coverage percentages


### PR DESCRIPTION
Merging this in so we can go back to using `stable/juno-pw-tweaks` branch instead of this topic branch.
